### PR TITLE
Метод text опция weigTH написана с ошибкой, правильно weigHT

### DIFF
--- a/Docs/Ru/Classes/Core/Context2D.md
+++ b/Docs/Ru/Classes/Core/Context2D.md
@@ -318,7 +318,7 @@ LibCanvas.Context2D
 
 `size`       (*int, по-умолчанию = 16*)
 
-`weigth`     (*string*) bold|normal
+`weight`     (*string*) bold|normal
 
 `style`      (*string*) italic|normal
 


### PR DESCRIPTION
Собственно в теме все и описано
