### PR TITLE
Circle.Intersect fix

### DIFF
--- a/Source/Shapes/Circle.js
+++ b/Source/Shapes/Circle.js
@@ -85,7 +85,7 @@ var Circle = LibCanvas.declare( 'LibCanvas.Shapes.Circle', 'Circle', Shape, {
 			deltaY = Math.abs(tC.y - oC.y);
 			if (deltaY >= minDist) return false;
 
-			return deltaX*deltaY < minDist*minDist;
+			return deltaX*deltaX + deltaY*deltaY < minDist * minDist;
 		} else {
 			return this.getBoundingRectangle().intersect( obj );
 		}


### PR DESCRIPTION
Оптимизированный обсчёт столкновений двух окружностей некорректный. Правильная формула для расчёта гипотенузы:

``` javascript
deltaX*deltaX + deltaY*deltaY = minDist*minDist
```

а не:

``` javascript
deltaX*deltaY = minDist*minDist
```
