### PR TITLE
Fixing the incorrect invocation of 'redraw' on elements array.

### DIFF
--- a/Source/App/Layer.js
+++ b/Source/App/Layer.js
@@ -75,7 +75,7 @@ declare( 'LibCanvas.App.Layer', {
 	},
 
 	redrawAll: function () {
-		this.elements.invoke('redraw');
+		atom.array.invoke( this.elements, 'redraw' );
 		return this;
 	},
 

--- a/libcanvas-full-compiled.js
+++ b/libcanvas-full-compiled.js
@@ -1129,7 +1129,7 @@ declare( 'LibCanvas.App.Layer', {
 	},
 
 	redrawAll: function () {
-		this.elements.invoke('redraw');
+		atom.array.invoke( this.elements, 'redraw' );
 		return this;
 	},
 


### PR DESCRIPTION
Fixing the error in 'LibCanvas.App.Layer' class in the 'redrawAll()' method. The incorrect invocation of 'redraw' on elements array.
